### PR TITLE
Fix broken search form when setting from/to by typing into inputs

### DIFF
--- a/saturday-afternoon/.babelrc
+++ b/saturday-afternoon/.babelrc
@@ -1,8 +1,0 @@
-{
-  "presets": [
-    "next/babel"
-  ],
-  "plugins": [
-    "relay"
-  ]
-}

--- a/saturday-afternoon/components/search/SearchForm.js
+++ b/saturday-afternoon/components/search/SearchForm.js
@@ -38,8 +38,16 @@ class SearchForm extends React.Component<Props, State> {
     this.setState({ from: option.props.children });
   };
 
-  changeTo = (value: string, option: Object) => {
+  handleSearchFrom = (from: string) => {
+    this.setState({ from });
+  };
+
+  handleChangeTo = (value: string, option: Object) => {
     this.setState({ to: option.props.children });
+  };
+
+  handleSearchTo = (to: string) => {
+    this.setState({ to });
   };
 
   changeDate = (date: Object, dateString: string) => {
@@ -47,6 +55,10 @@ class SearchForm extends React.Component<Props, State> {
   };
 
   handleSearchClick = () => {
+    if (!this.isSearchable()) {
+      return;
+    }
+
     this.props.onSubmit(this.state);
   };
 
@@ -72,7 +84,6 @@ class SearchForm extends React.Component<Props, State> {
   };
 
   render() {
-    const props = this.props;
     const state = this.state;
 
     return (
@@ -82,6 +93,7 @@ class SearchForm extends React.Component<Props, State> {
             <Form.Item label="From" colon>
               <AutoComplete
                 value={state.from}
+                onSearch={this.handleSearchFrom}
                 onSelect={this.changeFrom}
                 filterOption
               >
@@ -93,7 +105,8 @@ class SearchForm extends React.Component<Props, State> {
             <Form.Item label="To" colon>
               <AutoComplete
                 value={state.to}
-                onSelect={this.changeTo}
+                onSearch={this.handleSearchTo}
+                onSelect={this.handleChangeTo}
                 filterOption
               >
                 {this.generateOptions()}

--- a/saturday-afternoon/components/search/SearchForm.test.js
+++ b/saturday-afternoon/components/search/SearchForm.test.js
@@ -1,0 +1,54 @@
+// @flow
+
+import * as React from "react";
+import { shallow } from "enzyme";
+import { Button } from "antd";
+
+import SearchForm from "./SearchForm";
+
+const getComponent = (props = {}) => {
+  const defaultProps = {
+    from: "Barcelona",
+    to: "Prague",
+    date: "2018-03-18",
+    onSubmit: jest.fn(),
+    locations: {
+      edges: [
+        {
+          node: {
+            locationId: "prague_cz",
+            name: "Prague"
+          }
+        }
+      ]
+    }
+  };
+
+  return shallow(<SearchForm {...Object.assign({}, defaultProps, props)} />);
+};
+
+describe("SearchForm", () => {
+  it("can submit updated values", () => {
+    const onSubmit = jest.fn();
+    const searchForm = getComponent({ onSubmit });
+    const button = searchForm.find(Button);
+    button.simulate("click");
+
+    expect(button.props().disabled).toBe(false);
+    expect(onSubmit).toHaveBeenCalledWith({
+      from: "Barcelona",
+      to: "Prague",
+      date: "2018-03-18"
+    });
+  });
+
+  it("can't submit form without from/to location", () => {
+    const onSubmit = jest.fn();
+    const searchForm = getComponent({ onSubmit, to: "" });
+    const button = searchForm.find(Button);
+    button.simulate("click");
+
+    expect(button.props().disabled).toBe(true);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Before this fix, search form was usable only when selecting items from autocomplete, not by typing locations into form. 🐛 